### PR TITLE
Fix: Correct behavior when pasting single tile animation to multiple tiles

### DIFF
--- a/CopyPasteAnimations.js
+++ b/CopyPasteAnimations.js
@@ -159,12 +159,17 @@ copyPasteAnimations.pasteAnimations = tiled.registerAction("PasteTileAnimations"
 		for(let dst = 0; dst < selectedTiles.length; ++dst) {
 			let dstTile = selectedTiles[dst];
 			if(copyPasteAnimations.copiedFrom.length == 1) {
-				copyPasteAnimations.pasteAnimation(dstTile, copyPasteAnimations.copiedFrom[0], copyPasteAnimations.copiedAnimations[0]);
+				// When pasting to multiple tiles, we need to deep-copy the frames,
+				// because the paste function may modify them.
+				let framesCopy = JSON.parse(JSON.stringify(copyPasteAnimations.copiedAnimations[0]));
+				copyPasteAnimations.pasteAnimation(dstTile, copyPasteAnimations.copiedFrom[0], framesCopy);
 				continue;
 			}
 			if(dst >= copyPasteAnimations.copiedFrom.length)
 				break;
-			copyPasteAnimations.pasteAnimation(dstTile, copyPasteAnimations.copiedFrom[dst], copyPasteAnimations.copiedAnimations[dst]);
+			// We probably don't need to copy here, but for safety...
+			let framesCopy = JSON.parse(JSON.stringify(copyPasteAnimations.copiedAnimations[dst]));
+			copyPasteAnimations.pasteAnimation(dstTile, copyPasteAnimations.copiedFrom[dst], framesCopy);
 		}
 	});
 });


### PR DESCRIPTION
This pull request addresses an issue where pasting an animation from a single tile to multiple tiles would cause unexpected behavior in "Adjust ID" and "Adjust Position" modes.

Before the fix:
When pasting a single animation to multiple destinations, the `newFrames` object was being modified in place during the first paste operation. Subsequent paste operations would then use this already-modified object, leading to incorrect frame calculations for the other tiles.

For example, in "Adjust ID" mode, the `tileId` of frames would be adjusted for the first destination tile. When pasting to the second destination tile, the adjustment would be based on the already adjusted `tileId`, not the original one, resulting in a cumulative and incorrect offset.

After the fix:
The issue is resolved by creating a deep copy of the original animation frames for each destination tile before the paste operation.

```
// When pasting to multiple tiles, we need to deep-copy the frames,
// because the paste function may modify them.
let framesCopy = JSON.parse(JSON.stringify(copyPasteAnimations.copiedAnimations[0]));
copyPasteAnimations.pasteAnimation(dstTile, copyPasteAnimations.copiedFrom[0], framesCopy);
```

By using `JSON.parse(JSON.stringify(...))`, we ensure that each call to `pasteAnimation` receives a fresh, unmodified copy of the original frames. This guarantees that the frame adjustments are always calculated based on the original source tile's data, producing the correct and expected result for all selected destination tiles.